### PR TITLE
chore: auto-switch Node to .nvmrc version on cd

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -75,3 +75,26 @@ esac
 
 # Configure direnv
 eval "$(direnv hook zsh)"
+
+# Auto-switch Node version on cd when a .nvmrc is present (nvm deeper-shell-integration).
+# Placed last so nvm's PATH entry wins over Homebrew node / other prepends above.
+autoload -U add-zsh-hook
+load-nvmrc() {
+  local nvmrc_path
+  nvmrc_path="$(nvm_find_nvmrc)"
+  if [ -n "$nvmrc_path" ]; then
+    local nvmrc_node_version
+    nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+    if [ "$nvmrc_node_version" = "N/A" ]; then
+      nvm install
+    elif [ "$nvmrc_node_version" != "$(nvm version)" ]; then
+      nvm use
+    fi
+  elif [ "$(nvm version)" != "$(nvm version default)" ]; then
+    # No .nvmrc here — fall back to the nvm default (so every shell uses it, not just project dirs)
+    nvm use default
+  fi
+}
+add-zsh-hook chpwd load-nvmrc
+load-nvmrc
+


### PR DESCRIPTION
## Summary

Adds an nvm `chpwd` hook so each shell automatically uses a repo's `.nvmrc` Node version on `cd` (and falls back to the nvm default everywhere else). Placed after all PATH-modifying lines so nvm's bin wins over a Homebrew-installed `node`.

## Why

CI for a project (canairy-client) runs ESLint on Node 24, where `eslint-plugin-react-hooks` v7 React Compiler rules are active — but locally on Node 22 those rules silently report 0 errors, so lint looked clean while CI failed. A Homebrew `node@25` was also shadowing nvm in PATH. This hook makes local Node match each project's `.nvmrc` automatically.

## Test plan

- [x] New shell starting in `$HOME` (no `.nvmrc`) → nvm default (Node 24)
- [x] `cd` into a repo with `.nvmrc=24` → auto-switches to v24.12.0
- [x] Hook runs after pyenv/poetry/pnpm PATH lines so nvm node resolves first