### PR TITLE
feat: add fzf helpers for aws profiles and sso login

### DIFF
--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -3,10 +3,12 @@
 #
 # Preview pane: Ctrl-D/Ctrl-U to scroll, Ctrl-/ to toggle
 # Plain functions (no become) so export AWS_PROFILE affects the current shell
+#
+# Everything reads local files (~/.aws/config, ~/.aws/sso/cache) — the aws
+# CLI is a Python program with seconds of cold start, only `aws sso login`
+# actually needs it
 
 # Profile list for the left column, active profile (AWS_PROFILE) in bold green
-# Parsed straight from ~/.aws/config + ~/.aws/credentials — `aws configure
-# list-profiles` is the Python CLI and takes seconds before fzf can even open
 _fzf_aws_profiles() {
   {
     [ -f ~/.aws/config ] &&
@@ -17,7 +19,7 @@ _fzf_aws_profiles() {
     awk -v cur="$AWS_PROFILE" '{if ($0 == cur) printf "\033[1;32m%s\033[0m\n", $0; else print}'
 }
 
-# Who a profile maps to per ~/.aws/config (account + role, no network call)
+# Who a profile maps to per ~/.aws/config (account + role)
 _fzf_aws_whois() {
   awk -v prof="$1" 'BEGIN{h="[profile " prof "]"; b="[" prof "]"}
     $0==h||$0==b{f=1;next} /^\[/{f=0}
@@ -25,40 +27,82 @@ _fzf_aws_whois() {
     END{if (acct) print acct " " role}' ~/.aws/config
 }
 
+# "active: <profile> → <account> <role>" line for a profile
+_fzf_aws_active() {
+  local who
+  who=$(_fzf_aws_whois "$1")
+  print -r -- "active: $1${who:+ → $who}"
+}
+
 # fzf --header showing current AWS_PROFILE and its mapping above the hint line
 _fzf_aws_header() {
-  local who
-  if [ -n "$AWS_PROFILE" ]; then
-    who=$(_fzf_aws_whois "$AWS_PROFILE")
-    print -r -- "active: $AWS_PROFILE${who:+ → $who}"
-  fi
+  [ -n "$AWS_PROFILE" ] && _fzf_aws_active "$AWS_PROFILE"
   print -r -- "$1"
 }
 
-# Preview: instant profile section from ~/.aws/config via awk, then the slow
-# caller-identity check streams in below as parseable key: value lines
-_fzf_aws_preview='p={}
-awk -v prof="$p" '\''BEGIN{h="[profile " prof "]"; b="[" prof "]"} $0==h||$0==b{f=1} /^\[/&&$0!=h&&$0!=b{f=0} f'\'' ~/.aws/config
-echo
-[ "$AWS_PROFILE" = "$p" ] && echo "● active (AWS_PROFILE)"
-arn=$(aws sts get-caller-identity --profile "$p" --query Arn --output text 2>/dev/null) &&
-  echo "$arn" | awk -F: '\''{print "account: " $5 "\ncaller:  " $6}'\'' ||
-  echo "✗ no valid session"'
+# SSO start URL for a profile — via its sso_session section or inline legacy key
+_fzf_aws_sso_url() {
+  awk -v prof="$1" '
+    /^\[/{sec=substr($0,2,length($0)-2)}
+    $1=="sso_session" && (sec=="profile " prof || sec==prof) {sess=$3}
+    $1=="sso_start_url" {
+      if (sec=="profile " prof || sec==prof) purl=$3
+      if (index(sec,"sso-session ")==1) surl[substr(sec,13)]=$3
+    }
+    END{if (purl) print purl; else if (sess != "") print surl[sess]}
+  ' ~/.aws/config
+}
 
-# faws - pick an AWS profile, export it, SSO login if creds are missing/expired
+# Cached SSO token expiry for a profile from ~/.aws/sso/cache; fails if none
+_fzf_aws_sso_expiry() {
+  local url exp
+  url=$(_fzf_aws_sso_url "$1")
+  [ -n "$url" ] || return 1
+  exp=$(grep -lF "\"startUrl\": \"$url\"" ~/.aws/sso/cache/*.json 2>/dev/null |
+    xargs grep -ho '"expiresAt": *"[^"]*"' 2>/dev/null | cut -d'"' -f4 | sort | tail -1)
+  [ -n "$exp" ] || return 1
+  print -r -- "$exp"
+}
+
+# True if the profile has a cached, unexpired SSO token
+_fzf_aws_sso_ok() {
+  local exp
+  exp=$(_fzf_aws_sso_expiry "$1") || return 1
+  [[ "$exp" > "$(date -u +%Y-%m-%dT%H:%M:%SZ)" ]]
+}
+
+# Preview: profile section from ~/.aws/config + active marker + sso status,
+# all from local files so it renders instantly
+_fzf_aws_preview() {
+  local p="$1" exp
+  awk -v prof="$p" 'BEGIN{h="[profile " prof "]"; b="[" prof "]"}
+    $0==h||$0==b{f=1} /^\[/&&$0!=h&&$0!=b{f=0} f' ~/.aws/config
+  echo
+  [ "$AWS_PROFILE" = "$p" ] && echo "● active (AWS_PROFILE)"
+  if exp=$(_fzf_aws_sso_expiry "$p"); then
+    if [[ "$exp" > "$(date -u +%Y-%m-%dT%H:%M:%SZ)" ]]; then
+      echo "sso: ✓ valid until $exp"
+    else
+      echo "sso: ✗ expired $exp"
+    fi
+  elif [ -n "$(_fzf_aws_sso_url "$p")" ]; then
+    echo "sso: ✗ not logged in"
+  fi
+}
+
+# faws - pick an AWS profile, export it, SSO login if token is missing/expired
 faws() {
-  local profile arn
+  local profile
   profile=$(_fzf_aws_profiles |
     fzf --ansi --no-sort \
-      --preview "$_fzf_aws_preview" \
+      --preview 'source ~/.sourced_fzf-aws; _fzf_aws_preview {}' \
       --preview-window=right:60%:wrap \
       --header "$(_fzf_aws_header 'Enter: switch profile (auto SSO login if needed) | green = active')") || return
   export AWS_PROFILE="$profile"
-  arn=$(aws sts get-caller-identity --query Arn --output text 2>/dev/null) || {
+  if [ -n "$(_fzf_aws_sso_url "$profile")" ] && ! _fzf_aws_sso_ok "$profile"; then
     aws sso login --profile "$profile" || return
-    arn=$(aws sts get-caller-identity --query Arn --output text) || return
-  }
-  echo "$arn" | awk -F: '{print "account: " $5 "\ncaller:  " $6}'
+  fi
+  _fzf_aws_active "$profile"
 }
 
 # fawslogin - pick an AWS profile and run SSO login without switching profiles
@@ -66,7 +110,7 @@ fawslogin() {
   local profile
   profile=$(_fzf_aws_profiles |
     fzf --ansi --no-sort \
-      --preview "$_fzf_aws_preview" \
+      --preview 'source ~/.sourced_fzf-aws; _fzf_aws_preview {}' \
       --preview-window=right:60%:wrap \
       --header "$(_fzf_aws_header 'Enter: aws sso login | green = active')") || return
   aws sso login --profile "$profile"

--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -4,33 +4,46 @@
 # Preview pane: Ctrl-D/Ctrl-U to scroll, Ctrl-/ to toggle
 # Plain functions (no become) so export AWS_PROFILE affects the current shell
 
+# Profile list for the left column, active profile (AWS_PROFILE) in bold green
+_fzf_aws_profiles() {
+  aws configure list-profiles | sort |
+    awk -v cur="$AWS_PROFILE" '{if ($0 == cur) printf "\033[1;32m%s\033[0m\n", $0; else print}'
+}
+
 # Preview: instant profile section from ~/.aws/config via awk, then the slow
-# live check (exported marker + sts get-caller-identity) streams in below it
-_fzf_aws_preview="awk -v prof={} 'BEGIN{p=\"[profile \" prof \"]\"; d=\"[\" prof \"]\"} \$0==p||\$0==d{f=1} /^\[/&&\$0!=p&&\$0!=d{f=0} f' ~/.aws/config; echo; [ \"\$AWS_PROFILE\" = {} ] && echo '● exported in this shell (AWS_PROFILE)'; aws sts get-caller-identity --output table --profile {} 2>/dev/null || echo '✗ no valid session — pick it in faws or fawslogin'"
+# caller-identity check streams in below as parseable key: value lines
+_fzf_aws_preview='p={}
+awk -v prof="$p" '\''BEGIN{h="[profile " prof "]"; b="[" prof "]"} $0==h||$0==b{f=1} /^\[/&&$0!=h&&$0!=b{f=0} f'\'' ~/.aws/config
+echo
+[ "$AWS_PROFILE" = "$p" ] && echo "● active (AWS_PROFILE)"
+arn=$(aws sts get-caller-identity --profile "$p" --query Arn --output text 2>/dev/null) &&
+  echo "$arn" | awk -F: '\''{print "account: " $5 "\ncaller:  " $6}'\'' ||
+  echo "✗ no valid session"'
 
 # faws - pick an AWS profile, export it, SSO login if creds are missing/expired
 faws() {
-  local profile
-  profile=$(aws configure list-profiles | sort |
-    fzf --no-sort \
+  local profile arn
+  profile=$(_fzf_aws_profiles |
+    fzf --ansi --no-sort \
       --preview "$_fzf_aws_preview" \
       --preview-window=right:60%:wrap \
-      --header 'Enter: switch profile (auto SSO login if needed)') || return
+      --header 'Enter: switch profile (auto SSO login if needed) | green = active') || return
   export AWS_PROFILE="$profile"
-  if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  arn=$(aws sts get-caller-identity --query Arn --output text 2>/dev/null) || {
     aws sso login --profile "$profile" || return
-  fi
-  aws sts get-caller-identity --output table
+    arn=$(aws sts get-caller-identity --query Arn --output text) || return
+  }
+  echo "$arn" | awk -F: '{print "account: " $5 "\ncaller:  " $6}'
 }
 
 # fawslogin - pick an AWS profile and run SSO login without switching profiles
 fawslogin() {
   local profile
-  profile=$(aws configure list-profiles | sort |
-    fzf --no-sort \
+  profile=$(_fzf_aws_profiles |
+    fzf --ansi --no-sort \
       --preview "$_fzf_aws_preview" \
       --preview-window=right:60%:wrap \
-      --header 'Enter: aws sso login') || return
+      --header 'Enter: aws sso login | green = active') || return
   aws sso login --profile "$profile"
 }
 

--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -4,12 +4,16 @@
 # Preview pane: Ctrl-D/Ctrl-U to scroll, Ctrl-/ to toggle
 # Plain functions (no become) so export AWS_PROFILE affects the current shell
 
+# Preview: instant profile section from ~/.aws/config via awk, then the slow
+# `aws configure list` (Python CLI, ~1s cold start) streams in below it
+_fzf_aws_preview="awk -v prof={} 'BEGIN{p=\"[profile \" prof \"]\"; d=\"[\" prof \"]\"} \$0==p||\$0==d{f=1} /^\[/&&\$0!=p&&\$0!=d{f=0} f' ~/.aws/config; echo; aws configure list --profile {}"
+
 # faws - pick an AWS profile, export it, SSO login if creds are missing/expired
 faws() {
   local profile
   profile=$(aws configure list-profiles | sort |
     fzf --no-sort \
-      --preview 'aws configure list --profile {}' \
+      --preview "$_fzf_aws_preview" \
       --preview-window=right:60%:wrap \
       --header 'Enter: switch profile (auto SSO login if needed)') || return
   export AWS_PROFILE="$profile"
@@ -24,7 +28,7 @@ fawslogin() {
   local profile
   profile=$(aws configure list-profiles | sort |
     fzf --no-sort \
-      --preview 'aws configure list --profile {}' \
+      --preview "$_fzf_aws_preview" \
       --preview-window=right:60%:wrap \
       --header 'Enter: aws sso login') || return
   aws sso login --profile "$profile"

--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -5,9 +5,34 @@
 # Plain functions (no become) so export AWS_PROFILE affects the current shell
 
 # Profile list for the left column, active profile (AWS_PROFILE) in bold green
+# Parsed straight from ~/.aws/config + ~/.aws/credentials — `aws configure
+# list-profiles` is the Python CLI and takes seconds before fzf can even open
 _fzf_aws_profiles() {
-  aws configure list-profiles | sort |
+  {
+    [ -f ~/.aws/config ] &&
+      awk '/^\[profile /{sub(/^\[profile /,""); sub(/\]$/,""); print} /^\[default\]/{print "default"}' ~/.aws/config
+    [ -f ~/.aws/credentials ] &&
+      awk -F'[][]' '/^\[/{print $2}' ~/.aws/credentials
+  } | sort -u |
     awk -v cur="$AWS_PROFILE" '{if ($0 == cur) printf "\033[1;32m%s\033[0m\n", $0; else print}'
+}
+
+# Who a profile maps to per ~/.aws/config (account + role, no network call)
+_fzf_aws_whois() {
+  awk -v prof="$1" 'BEGIN{h="[profile " prof "]"; b="[" prof "]"}
+    $0==h||$0==b{f=1;next} /^\[/{f=0}
+    f && $1=="sso_account_id"{acct=$3} f && $1=="sso_role_name"{role=$3}
+    END{if (acct) print acct " " role}' ~/.aws/config
+}
+
+# fzf --header showing current AWS_PROFILE and its mapping above the hint line
+_fzf_aws_header() {
+  local who
+  if [ -n "$AWS_PROFILE" ]; then
+    who=$(_fzf_aws_whois "$AWS_PROFILE")
+    print -r -- "active: $AWS_PROFILE${who:+ → $who}"
+  fi
+  print -r -- "$1"
 }
 
 # Preview: instant profile section from ~/.aws/config via awk, then the slow
@@ -27,7 +52,7 @@ faws() {
     fzf --ansi --no-sort \
       --preview "$_fzf_aws_preview" \
       --preview-window=right:60%:wrap \
-      --header 'Enter: switch profile (auto SSO login if needed) | green = active') || return
+      --header "$(_fzf_aws_header 'Enter: switch profile (auto SSO login if needed) | green = active')") || return
   export AWS_PROFILE="$profile"
   arn=$(aws sts get-caller-identity --query Arn --output text 2>/dev/null) || {
     aws sso login --profile "$profile" || return
@@ -43,7 +68,7 @@ fawslogin() {
     fzf --ansi --no-sort \
       --preview "$_fzf_aws_preview" \
       --preview-window=right:60%:wrap \
-      --header 'Enter: aws sso login | green = active') || return
+      --header "$(_fzf_aws_header 'Enter: aws sso login | green = active')") || return
   aws sso login --profile "$profile"
 }
 

--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -21,6 +21,7 @@ _fzf_aws_profiles() {
 
 # Who a profile maps to per ~/.aws/config (account + role)
 _fzf_aws_whois() {
+  [ -f ~/.aws/config ] || return 1
   awk -v prof="$1" 'BEGIN{h="[profile " prof "]"; b="[" prof "]"}
     $0==h||$0==b{f=1;next} /^\[/{f=0}
     f && $1=="sso_account_id"{acct=$3} f && $1=="sso_role_name"{role=$3}
@@ -42,6 +43,7 @@ _fzf_aws_header() {
 
 # SSO start URL for a profile — via its sso_session section or inline legacy key
 _fzf_aws_sso_url() {
+  [ -f ~/.aws/config ] || return 1
   awk -v prof="$1" '
     /^\[/{sec=substr($0,2,length($0)-2)}
     $1=="sso_session" && (sec=="profile " prof || sec==prof) {sess=$3}
@@ -75,8 +77,9 @@ _fzf_aws_sso_ok() {
 # all from local files so it renders instantly
 _fzf_aws_preview() {
   local p="$1" exp
-  awk -v prof="$p" 'BEGIN{h="[profile " prof "]"; b="[" prof "]"}
-    $0==h||$0==b{f=1} /^\[/&&$0!=h&&$0!=b{f=0} f' ~/.aws/config
+  [ -f ~/.aws/config ] &&
+    awk -v prof="$p" 'BEGIN{h="[profile " prof "]"; b="[" prof "]"}
+      $0==h||$0==b{f=1} /^\[/&&$0!=h&&$0!=b{f=0} f' ~/.aws/config
   echo
   [ "$AWS_PROFILE" = "$p" ] && echo "● active (AWS_PROFILE)"
   if exp=$(_fzf_aws_sso_expiry "$p"); then
@@ -98,10 +101,10 @@ faws() {
       --preview 'source ~/.sourced_fzf-aws; _fzf_aws_preview {}' \
       --preview-window=right:60%:wrap \
       --header "$(_fzf_aws_header 'Enter: switch profile (auto SSO login if needed) | green = active')") || return
-  export AWS_PROFILE="$profile"
   if [ -n "$(_fzf_aws_sso_url "$profile")" ] && ! _fzf_aws_sso_ok "$profile"; then
     aws sso login --profile "$profile" || return
   fi
+  export AWS_PROFILE="$profile"
   _fzf_aws_active "$profile"
 }
 
@@ -113,6 +116,10 @@ fawslogin() {
       --preview 'source ~/.sourced_fzf-aws; _fzf_aws_preview {}' \
       --preview-window=right:60%:wrap \
       --header "$(_fzf_aws_header 'Enter: aws sso login | green = active')") || return
+  if [ -z "$(_fzf_aws_sso_url "$profile")" ]; then
+    echo "✗ $profile has no SSO config" >&2
+    return 1
+  fi
   aws sso login --profile "$profile"
 }
 

--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -5,8 +5,8 @@
 # Plain functions (no become) so export AWS_PROFILE affects the current shell
 
 # Preview: instant profile section from ~/.aws/config via awk, then the slow
-# `aws configure list` (Python CLI, ~1s cold start) streams in below it
-_fzf_aws_preview="awk -v prof={} 'BEGIN{p=\"[profile \" prof \"]\"; d=\"[\" prof \"]\"} \$0==p||\$0==d{f=1} /^\[/&&\$0!=p&&\$0!=d{f=0} f' ~/.aws/config; echo; aws configure list --profile {}"
+# live check (exported marker + sts get-caller-identity) streams in below it
+_fzf_aws_preview="awk -v prof={} 'BEGIN{p=\"[profile \" prof \"]\"; d=\"[\" prof \"]\"} \$0==p||\$0==d{f=1} /^\[/&&\$0!=p&&\$0!=d{f=0} f' ~/.aws/config; echo; [ \"\$AWS_PROFILE\" = {} ] && echo '● exported in this shell (AWS_PROFILE)'; aws sts get-caller-identity --output table --profile {} 2>/dev/null || echo '✗ no valid session — pick it in faws or fawslogin'"
 
 # faws - pick an AWS profile, export it, SSO login if creds are missing/expired
 faws() {

--- a/sourced/fzf-aws
+++ b/sourced/fzf-aws
@@ -1,0 +1,36 @@
+# AWS + fzf helpers
+# Sourced automatically via dotfiles sourced/ dir
+#
+# Preview pane: Ctrl-D/Ctrl-U to scroll, Ctrl-/ to toggle
+# Plain functions (no become) so export AWS_PROFILE affects the current shell
+
+# faws - pick an AWS profile, export it, SSO login if creds are missing/expired
+faws() {
+  local profile
+  profile=$(aws configure list-profiles | sort |
+    fzf --no-sort \
+      --preview 'aws configure list --profile {}' \
+      --preview-window=right:60%:wrap \
+      --header 'Enter: switch profile (auto SSO login if needed)') || return
+  export AWS_PROFILE="$profile"
+  if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    aws sso login --profile "$profile" || return
+  fi
+  aws sts get-caller-identity --output table
+}
+
+# fawslogin - pick an AWS profile and run SSO login without switching profiles
+fawslogin() {
+  local profile
+  profile=$(aws configure list-profiles | sort |
+    fzf --no-sort \
+      --preview 'aws configure list --profile {}' \
+      --preview-window=right:60%:wrap \
+      --header 'Enter: aws sso login') || return
+  aws sso login --profile "$profile"
+}
+
+# fawsoff - clear the active AWS profile from the current shell
+fawsoff() {
+  unset AWS_PROFILE AWS_DEFAULT_PROFILE
+}


### PR DESCRIPTION
## Summary
- New `sourced/fzf-aws` with three AWS + fzf helpers, matching the `sourced/fzf-git` conventions:
  - `faws` — pick a profile, `export AWS_PROFILE`, auto `aws sso login` if creds are missing/expired, then print the caller identity
  - `fawslogin` — pick a profile and run `aws sso login` without switching the active profile
  - `fawsoff` — unset `AWS_PROFILE` / `AWS_DEFAULT_PROFILE`
- Plain functions (not `become` subshells) so the export/unset affects the current shell

## Test plan
- [ ] `zsh -n sourced/fzf-aws` passes (verified)
- [ ] `ln -sf` to `~/.sourced_fzf-aws`, open a new shell, confirm the three functions are defined
- [ ] `faws` with expired SSO creds triggers `aws sso login` then prints identity table
- [ ] `fawsoff` clears `AWS_PROFILE` in the current shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive AWS profile picker for easier switching between local profiles.
  * Added quick actions to log in to AWS SSO, select a profile without changing the current session, and clear the active AWS profile settings.
  * Included a preview view that shows profile details and SSO status before selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->